### PR TITLE
Add `have_hash` matcher and fix `js_enabled?` bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ require 'utensils/factory_bot'
 require 'utensils/omniauth'
 require 'utensils/upload_macros'
 require 'utensils/json'
+require 'utensils/have_hash_matcher'
 ```
 
 ### capybara_extensions
@@ -85,4 +86,12 @@ Provides fixture_file and fixture_file_path helper pointing to spec/fixtures dir
 ```ruby
 fixture_file_path('dummy.jpg') # 'spec/fixtures/dummy.jpg'
 Photo.create(:file => fixture_file('dummy.jpg')) # attaches File spec/fixtures/dummy.jpg
+```
+
+### have_hash_matcher
+
+Matcher for checking whether a given array contains a hash that `include`s a given hash. In JS specs, waits up to `Capybara.default_max_wait_time` for the array to have a matching hash.
+
+```ruby
+expect(ActivityLogger.queue).to have_hash(event: "recipe.visit")
 ```

--- a/lib/utensils/have_hash_matcher.rb
+++ b/lib/utensils/have_hash_matcher.rb
@@ -1,0 +1,60 @@
+RSpec::Matchers.define :have_hash do |expected|
+  match do |array|
+    synchronize do
+      hash = find_hash(array, expected)
+
+      expect(hash).to include(expected)
+      expect(hash).to_not include(@unexpected_keys)
+    end
+  end
+
+  chain :without do |*unexpected_keys|
+    @unexpected_keys = unexpected_keys
+  end
+
+  failure_message do
+    @failure_message
+  end
+
+  private
+
+    def find_hash(array, expected)
+      hash = array.reverse.find do |item|
+        find_with_inclusion(item, expected)
+      end
+
+      hash || better_diff(array)
+    end
+
+    def find_with_inclusion(hash, expected)
+      expect(hash).to include(expected)
+    rescue RSpec::Expectations::ExpectationNotMetError
+    end
+
+    def better_diff(array)
+      return array if array.size > 1
+
+      array.first
+    end
+
+    # mimicking has_text/css? matchers, https://git.io/vMSo9
+    def synchronize(&block)
+      start_time = Time.current
+
+      begin
+        block.call
+      rescue ::RSpec::Expectations::ExpectationNotMetError => e
+        @failure_message = e.message
+        raise(e) unless js_enabled?
+
+        return false if (Time.current - start_time) >= Capybara.default_max_wait_time
+
+        sleep 0.05
+        retry
+      end
+    end
+
+    def js_enabled?
+      RSpec.current_example.metadata[:js]
+    end
+end

--- a/lib/utensils/have_hash_matcher.rb
+++ b/lib/utensils/have_hash_matcher.rb
@@ -55,6 +55,8 @@ RSpec::Matchers.define :have_hash do |expected|
     end
 
     def js_enabled?
-      RSpec.current_example.metadata[:js]
+      !!page.evaluate_script("0 + 1")
+    rescue Capybara::NotSupportedByDriverError
+      false
     end
 end


### PR DESCRIPTION
## What

1. Copies the `have_hash` matcher from [streamy](https://github.com/cookpad/streamy/blob/main/lib/streamy/helpers/have_hash_matcher.rb), so the matcher can be included in projects with `require "utensils/have_hash_matcher"`.

2. Updates the check for whether the spec has `js` enabled using `RSpec.current_example.metadata[:js]` instead of `Capybara.current_driver == Capybara.javascript_driver`.

## Why

1. We use `have_hash` in `global-web` when checking for an activity log in the activity logs queue. Currently, `have_hash` is available because we `require "streamy/helpers/rspec_helper"` in a separate spec helper. We're relying on `streamy` for our activity logs specs, which are totally unrelated. Including `have_hash` as a standalone feature, not tied to `streamy`, is clearer.

2. There is currently a bug in `have_hash`, explained [here](https://github.com/cookpad/global-web/pull/31236#issue-1278256388). It's possible for a spec to have `js` enabled but for `Capybara.current_driver` _not to_ be  `Capybara.javascript_driver`. In some `global-web` specs, this is the case when the current driver is `mobile_chrome` instead of `chrome`. The result is that in such specs `have_hash` doesn't wait for the array to contain a matching `hash`, resulting in flakey specs. This explains our flakiest spec [at the moment](https://upgraded-guide-a6048edf.pages.github.io/flaky/).

## How

Copied the matcher from `streamy` and replaced the `js_enabled?` check with a more generic/robust one suggested by @tejanium [here](https://github.com/cookpad/global-web/pull/31236#issuecomment-1161937926).

I've checked locally that this update (and requiring "utensils/have_hash_matcher") fixes the flakey spec.

## Anything else

Next steps would be:
- use this forked gem in `global-web` instead of [this one](https://github.com/balvig/utensils)
- add `require "utensils/have_hash_matcher"` in `global-web` (in a helper file that is required by `rails_helper`)
- update `streamy` to use `utensils` and `require "utensils/have_hash_matcher"` instead of defining its own distinct version