### PR TITLE
Fix `js_enabled?` check for request specs

### DIFF
--- a/lib/utensils/have_hash_matcher.rb
+++ b/lib/utensils/have_hash_matcher.rb
@@ -55,7 +55,7 @@ RSpec::Matchers.define :have_hash do |expected|
     end
 
     def js_enabled?
-      !!page.evaluate_script("0 + 1")
+      respond_to?(:page) && !!page.evaluate_script("0 + 1")
     rescue Capybara::NotSupportedByDriverError
       false
     end


### PR DESCRIPTION
## What

Followup to https://github.com/cookpad/utensils/pull/1

Updates the `js_enabled?` check so it doesn't error in request specs, where `page` is not available.

## Why

I tried using the updated `utensils` gem with the updated `have_hash`, and got lots of errors in specs ([here](https://app.circleci.com/pipelines/github/cookpad/global-web/88730/workflows/29b5c61f-ee48-4970-94b2-bac214cad279/jobs/323331) for example). We use `have_hash` in request specs as well as feature specs, so it needs to work when the `page` method is unavailable. In such cases, js is not enabled so the `js_enabled?` method should return false.

## How

Added a `respond_to?(:page)` check... which feels kind of awkward. Better suggestions welcome 😄.